### PR TITLE
Replace image name

### DIFF
--- a/deploy/replication-controller.json
+++ b/deploy/replication-controller.json
@@ -22,7 +22,7 @@
         "containers": [
           {
             "name": "kyrene-container",
-            "image": "gcr.io/mpj-test-1221/a73b0a65b7ad",
+            "image": "gcr.io/mpj-test-1221/kyrene:1",
             "ports": [
               {
                 "containerPort": 3000,


### PR DESCRIPTION
The image name on replication controller use your internal hash inside docker repository.
The deploy script tag the hash on build, then it is better use this tag instead of hash id. 
I tested in my internal kubernet cluster, but I think that it will work in gcloud cluster too.
Thanks
